### PR TITLE
Migrate from Chat Completions to Responses API

### DIFF
--- a/example.py
+++ b/example.py
@@ -24,15 +24,16 @@ client = openai.OpenAI(
     api_key=token_provider,
 )
 
-response = client.chat.completions.create(
+response = client.responses.create(
     # For Azure OpenAI, the model parameter must be set to the deployment name
     model=os.environ["AZURE_OPENAI_GPT_DEPLOYMENT"],
     temperature=0.7,
-    messages=[
+    input=[
         {"role": "system", "content": "You are a helpful assistant that makes lots of cat references and uses emojis."},
         {"role": "user", "content": "Write a haiku about a hungry cat who wants tuna"},
     ],
+    store=False,
 )
 
 print("Response: ")
-print(response.choices[0].message.content)
+print(response.output_text)


### PR DESCRIPTION
## Summary

Migrate `example.py` from the Chat Completions API to the Responses API.

## Changes

**File: `example.py`**

| Before | After |
|---|---|
| `client.chat.completions.create(messages=...)` | `client.responses.create(input=..., store=False)` |
| `response.choices[0].message.content` | `response.output_text` |
| `messages` parameter | `input` parameter |

### Details

- **API call**: `client.chat.completions.create()` → `client.responses.create()`
- **Parameter rename**: `messages` → `input`
- **Response access**: `response.choices[0].message.content` → `response.output_text`
- **Data retention**: Added `store=False` per Responses API best practice
- **No client constructor changes needed** — already using `openai.OpenAI` with the `/openai/v1` base URL

## Not changed

- Client constructor (already on `openai.OpenAI` with v1 endpoint)
- Dependencies (`openai>=1.108.1` and `azure-identity` already present)
- Environment variables (no deprecated vars like `AZURE_OPENAI_API_VERSION`)
- Infrastructure files

## Verification

Scanner reports zero legacy patterns:
```
python migrate.py scan . → [PASS] No legacy Chat Completions patterns found.
```